### PR TITLE
Increase default sequence lengths and token generation limits

### DIFF
--- a/src/chat_interface.py
+++ b/src/chat_interface.py
@@ -25,7 +25,7 @@ class ChatInterface:
         self,
         onnx_model_path: str,
         device: str = "cpu",
-        max_length: int = 256,
+        max_length: int = 512,
         log_conversations: bool = False,
         log_file: Optional[str] = None,
         auto_flush_interval: int = 10,
@@ -250,7 +250,7 @@ class ChatInterface:
     def generate_response(
         self,
         prompt: str,
-        max_new_tokens: int = 50,
+        max_new_tokens: int = 200,
         temperature: float = 0.7,
         top_p: float = 0.9,
         do_sample: bool = True,
@@ -282,16 +282,16 @@ class ChatInterface:
         )
         
         # Generate
-        with self.tokenizer.as_target_tokenizer():
-            outputs = self.model.generate(
-                **inputs,
-                max_new_tokens=max_new_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                do_sample=do_sample,
-                repetition_penalty=repetition_penalty,
-                pad_token_id=self.tokenizer.eos_token_id
-            )
+        outputs = self.model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            do_sample=do_sample,
+            repetition_penalty=repetition_penalty,
+            pad_token_id=self.tokenizer.eos_token_id,
+            eos_token_id=self.tokenizer.eos_token_id
+        )
         
         # Decode
         full_text = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
@@ -401,7 +401,7 @@ class ChatInterface:
     def batch_generate(
         self,
         prompts: List[str],
-        max_new_tokens: int = 50,
+        max_new_tokens: int = 200,
         **kwargs
     ) -> List[str]:
         """

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -67,7 +67,7 @@ class LLMTrainer:
         )
         self.model.to(self.device)
     
-    def prepare_dataset(self, texts: List[str], max_length: int = 256) -> Dataset:
+    def prepare_dataset(self, texts: List[str], max_length: int = 512) -> Dataset:
         """
         Prepare dataset for training.
         
@@ -103,7 +103,7 @@ class LLMTrainer:
         batch_size: int = 4,
         learning_rate: float = 5e-5,
         save_steps: int = 100,
-        max_length: int = 256,
+        max_length: int = 512,
         max_steps: int = -1
     ) -> None:
         """


### PR DESCRIPTION
## Summary
This PR increases the default maximum sequence lengths and token generation limits across the chat interface and trainer modules to support longer context windows and more verbose responses.

## Key Changes
- **Chat Interface (`src/chat_interface.py`)**
  - Increased default `max_length` from 256 to 512 tokens in `__init__`
  - Increased default `max_new_tokens` from 50 to 200 tokens in `generate_response()` method
  - Increased default `max_new_tokens` from 50 to 200 tokens in `batch_generate()` method
  - Removed `as_target_tokenizer()` context manager from model generation call
  - Added explicit `eos_token_id` parameter to `model.generate()` call

- **Trainer (`src/trainer.py`)**
  - Increased default `max_length` from 256 to 512 tokens in `prepare_dataset()` method
  - Increased default `max_length` from 256 to 512 tokens in `train()` method

## Notable Implementation Details
The removal of the `as_target_tokenizer()` context manager and addition of explicit `eos_token_id` parameter suggests a refactoring of the token generation logic, potentially for better compatibility or clearer token handling during inference.

https://claude.ai/code/session_01XYFsrQfhQSfUeKWapz5xs3