### PR TITLE
Add logging for feedback file conversation counts

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -167,6 +167,11 @@ def run_daemon(
             total_lines = count_jsonl_lines(feedback_file)
             new_lines = total_lines - state['lines_consumed']
 
+            logger.info(
+                "Conversations in feedback file: %d (%d new, %d already consumed).",
+                total_lines, new_lines, state['lines_consumed']
+            )
+
             if new_lines >= retrain_threshold:
                 logger.info(
                     "%d new examples found (threshold: %d) — starting retraining.",


### PR DESCRIPTION
## Summary
Added informational logging to the daemon's feedback file processing loop to provide visibility into the number of conversations being processed.

## Key Changes
- Added a log message that reports the total number of conversations in the feedback file, the count of new conversations, and the count of already-consumed conversations
- This logging occurs before the retraining threshold check, providing context for the retraining decision

## Implementation Details
The new log statement uses the existing logger and provides three metrics:
- `total_lines`: Total conversations in the feedback file
- `new_lines`: Newly discovered conversations since last check
- `state['lines_consumed']`: Previously processed conversations

This improves observability of the daemon's feedback processing without changing any functional behavior.

https://claude.ai/code/session_01FXHCtW5f1GWxyZbHqGEsxN