### PR TITLE
Add Qwen2.5-1.5B support with baseline export and fine-tuning

### DIFF
--- a/main.py
+++ b/main.py
@@ -545,6 +545,173 @@ def baseline_model(args):
         sys.exit(1)
 
 
+def qwen_baseline_model(args):
+    """
+    Export Qwen/Qwen2.5-1.5B to ONNX directly from Hugging Face — no training.
+
+    Downloads safetensors weights on first run (~3 GB) then converts to ONNX
+    using optimum-onnxruntime.  The result can be used with the 'chat' command
+    just like the DistilGPT-2 baseline.
+
+    Args:
+        args: Argument namespace with qwen_model, qwen_baseline_output, and test
+    """
+    from optimum.onnxruntime import ORTModelForCausalLM
+    from transformers import AutoTokenizer
+    from src.onnx_utils import suppress_onnx_export_warnings
+
+    print("=== Creating Qwen2.5-1.5B Baseline ONNX Model ===")
+    print()
+    print(f"📦 Base model : {args.qwen_model}")
+    print(f"📂 Output dir : {args.qwen_baseline_output}")
+    print()
+    print("Downloading safetensors from Hugging Face on first run (~3 GB).")
+    print("No training is performed — this is a clean export of the base model.")
+    print()
+
+    output_path = Path(args.qwen_baseline_output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    try:
+        print(f"Loading {args.qwen_model} and exporting to ONNX...")
+
+        with suppress_onnx_export_warnings():
+            model = ORTModelForCausalLM.from_pretrained(
+                args.qwen_model,
+                export=True
+            )
+
+        print(f"Saving ONNX model to {args.qwen_baseline_output}...")
+        model.save_pretrained(str(output_path))
+
+        print("Saving tokenizer...")
+        tokenizer = AutoTokenizer.from_pretrained(args.qwen_model)
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.save_pretrained(str(output_path))
+
+        print()
+        print(f"✅ Qwen2.5-1.5B baseline ONNX model saved to: {args.qwen_baseline_output}")
+
+        if args.test:
+            print()
+            print("=== Testing Baseline Model ===")
+            test_prompt = "Hello, I am a"
+            print(f"Test prompt: '{test_prompt}'")
+
+            inputs = tokenizer(test_prompt, return_tensors="pt")
+            outputs = model.generate(
+                **inputs,
+                max_new_tokens=20,
+                do_sample=True,
+                temperature=0.7,
+                top_p=0.9,
+                repetition_penalty=1.3,
+                no_repeat_ngram_size=3,
+            )
+            result = tokenizer.decode(outputs[0], skip_special_tokens=True)
+            print(f"Generated text: {result}")
+            print()
+            print("✅ Test successful!")
+
+        print()
+        print("Next steps:")
+        print(f"  Chat : python main.py chat --model-path {args.qwen_baseline_output} --prompt \"Your prompt\"")
+        print(f"  Train: python main.py qwen-train --data-file your_data.json")
+
+    except Exception as e:
+        print(f"❌ Error creating Qwen baseline model: {e}")
+        sys.exit(1)
+
+
+def qwen_train_model(args):
+    """
+    Fine-tune Qwen/Qwen2.5-1.5B on conversation data using QwenBuilder.
+
+    Mirrors train_model() but uses QwenBuilder with CPU-friendly defaults
+    (batch_size=1, gradient_accumulation=4, max_length=256, lr=2e-5).
+
+    Args:
+        args: Argument namespace — same shape as the 'train' command args
+    """
+    from src.data_handler import ConversationDataHandler
+    from src.qwen_builder import QwenBuilder
+
+    print("=== Training Qwen2.5-1.5B Model ===")
+
+    model_to_use = args.qwen_model
+    learning_rate_to_use = args.learning_rate
+    is_retraining = False
+
+    if check_model_exists(args.qwen_output_dir):
+        print(f"🔄 Found existing checkpoint at '{args.qwen_output_dir}'")
+        print("🔄 Continuing training from this checkpoint...")
+        model_to_use = args.qwen_output_dir
+        is_retraining = True
+        learning_rate_to_use = 1e-5
+        print(f"📚 Using lower learning rate ({learning_rate_to_use}) to preserve existing knowledge")
+    else:
+        print(f"🆕 Training new model from '{model_to_use}'")
+        print(f"📚 Using learning rate {learning_rate_to_use}")
+
+    print()
+
+    data_handler = ConversationDataHandler()
+    if args.data_file:
+        data_handler.load_from_json(args.data_file)
+    else:
+        print("No data file provided. Using built-in example conversations...")
+        data_handler.add_conversations([
+            {"input": "What is Python?", "output": "Python is a high-level programming language."},
+            {"input": "How do I install Python?", "output": "You can download Python from python.org."},
+            {"input": "What is machine learning?", "output": "Machine learning is a subset of AI."},
+        ])
+
+    print(f"Loaded {len(data_handler)} conversations")
+
+    print("\n=== Data Quality Analysis ===")
+    quality_report = data_handler.analyze_dataset_quality()
+    print(f"Total conversations  : {quality_report['total_conversations']}")
+    print(f"Valid conversations  : {quality_report['valid_conversations']}")
+    print(f"Quality score        : {quality_report['quality_score']:.1%}")
+
+    if quality_report['issue_summary']:
+        for issue_type, count in quality_report['issue_summary'].items():
+            if count > 0:
+                print(f"  - {issue_type.replace('_', ' ').title()}: {count}")
+
+    if quality_report['quality_score'] < 0.5:
+        print("\n⚠️  WARNING: Data quality is very low — results may be poor.")
+        if not args.force:
+            response = input("\nContinue anyway? (yes/no): ")
+            if response.lower() not in ['yes', 'y']:
+                print("Training cancelled.")
+                sys.exit(0)
+    elif quality_report['quality_score'] < 0.7:
+        print("\n⚠️  WARNING: Consider filtering out problematic conversations.\n")
+
+    train_texts = data_handler.format_for_training()
+
+    builder = QwenBuilder(
+        model_name=model_to_use,
+        output_dir=args.qwen_output_dir,
+        device=args.device
+    )
+
+    builder.train(
+        train_texts=train_texts,
+        num_epochs=args.epochs,
+        batch_size=args.batch_size,
+        learning_rate=learning_rate_to_use,
+        max_length=args.max_length
+    )
+
+    model_path = builder.save_model()
+    print(f"Model saved to: {model_path}")
+
+    return model_path
+
+
 def reset_model(args):
     """
     Reset model to original pretrained state by removing fine-tuned models.
@@ -745,7 +912,59 @@ def main():
                                 help='Output directory for baseline ONNX model (default: ./baseline_onnx)')
     baseline_parser.add_argument('--test', action='store_true',
                                 help='Test the model after export with a sample prompt')
-    
+
+    # Qwen2.5-1.5B baseline command — export from HF without training
+    qwen_baseline_parser = subparsers.add_parser(
+        'qwen-baseline',
+        help='Export Qwen/Qwen2.5-1.5B to ONNX from Hugging Face without training'
+    )
+    qwen_baseline_parser.add_argument(
+        '--qwen-model', type=str, default='Qwen/Qwen2.5-1.5B',
+        help='Hugging Face model ID (default: Qwen/Qwen2.5-1.5B)'
+    )
+    qwen_baseline_parser.add_argument(
+        '--qwen-baseline-output', type=str, default='./qwen_baseline_onnx',
+        help='Output directory for the ONNX model (default: ./qwen_baseline_onnx)'
+    )
+    qwen_baseline_parser.add_argument(
+        '--test', action='store_true',
+        help='Run a quick generation test after export'
+    )
+
+    # Qwen2.5-1.5B train command
+    qwen_train_parser = subparsers.add_parser(
+        'qwen-train',
+        help='Fine-tune Qwen/Qwen2.5-1.5B on conversation data'
+    )
+    qwen_train_parser.add_argument('--data-file', type=str,
+                                   help='Path to conversation data JSON')
+    qwen_train_parser.add_argument(
+        '--qwen-model', type=str, default='Qwen/Qwen2.5-1.5B',
+        help='Base model ID or path to existing checkpoint (default: Qwen/Qwen2.5-1.5B)'
+    )
+    qwen_train_parser.add_argument(
+        '--qwen-output-dir', type=str, default='./qwen_trained_model',
+        help='Directory to save the trained model (default: ./qwen_trained_model)'
+    )
+    qwen_train_parser.add_argument('--device', type=str, default='cpu',
+                                   help='Compute device (default: cpu)')
+    qwen_train_parser.add_argument('--epochs', type=int, default=3,
+                                   help='Training epochs (default: 3)')
+    qwen_train_parser.add_argument(
+        '--batch-size', type=int, default=1,
+        help='Per-device batch size (default: 1; gradient_accumulation=4 is applied internally)'
+    )
+    qwen_train_parser.add_argument(
+        '--learning-rate', type=float, default=2e-5,
+        help='Peak learning rate (default: 2e-5)'
+    )
+    qwen_train_parser.add_argument(
+        '--max-length', type=int, default=256,
+        help='Maximum token sequence length (default: 256)'
+    )
+    qwen_train_parser.add_argument('--force', action='store_true',
+                                   help='Skip data quality warnings')
+
     args = parser.parse_args()
     
     if not args.command:
@@ -769,6 +988,10 @@ def main():
             taber_bridge(args)
         elif args.command == 'baseline':
             baseline_model(args)
+        elif args.command == 'qwen-baseline':
+            qwen_baseline_model(args)
+        elif args.command == 'qwen-train':
+            qwen_train_model(args)
         elif args.command == 'daemon':
             run_daemon_command(args)
     except Exception as e:

--- a/src/qwen_builder.py
+++ b/src/qwen_builder.py
@@ -1,0 +1,265 @@
+"""
+Qwen2.5-1.5B model builder for fine-tuning on conversation data.
+
+Downloads safetensors weights directly from Hugging Face.
+CPU-friendly defaults: batch_size=1, max_length=256, gradient_accumulation=4.
+"""
+
+import warnings
+import torch
+import gc
+import shutil
+import tempfile
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    TrainingArguments,
+    Trainer,
+    DataCollatorForLanguageModeling
+)
+from datasets import Dataset
+from typing import List, Optional
+from pathlib import Path
+
+warnings.filterwarnings('ignore', category=FutureWarning, module='transformers')
+warnings.filterwarnings('ignore', message='.*loss_type.*')
+
+DEFAULT_MODEL_ID = "Qwen/Qwen2.5-1.5B"
+
+
+class QwenBuilder:
+    """
+    Loads, fine-tunes, and saves Qwen/Qwen2.5-1.5B models.
+
+    Mirrors the LLMTrainer API so it can be swapped in anywhere that class is
+    used, but ships with CPU-friendly defaults appropriate for a 1.5 B model:
+      - batch_size=1 (with gradient_accumulation_steps=4 to stay stable)
+      - max_length=256 tokens
+      - learning_rate=2e-5
+    """
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_MODEL_ID,
+        output_dir: str = "./qwen_trained_model",
+        device: str = "cpu"
+    ):
+        """
+        Initialize the Qwen builder.
+
+        Args:
+            model_name: Hugging Face model ID (default: Qwen/Qwen2.5-1.5B)
+            output_dir: Directory to save checkpoints and the final model
+            device: Compute device ('cpu' or 'cuda')
+        """
+        self.model_name = model_name
+        self.output_dir = Path(output_dir)
+        self.device = device
+        self.model = None
+        self.tokenizer = None
+
+        self._load_model()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_model(self) -> None:
+        """Download (on first use) and load the model + tokenizer."""
+        print(f"Loading model: {self.model_name}")
+        print("Note: Qwen2.5-1.5B weights are ~3 GB; first run will download them.")
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.model_name,
+            trust_remote_code=False  # Qwen2.5 is natively supported in transformers >=4.37
+        )
+
+        # Qwen2.5 tokenizer uses <|endoftext|> for EOS; mirror it to PAD so
+        # the DataCollator can build attention masks correctly.
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        if self.tokenizer.pad_token_id is None:
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.model_name,
+            torch_dtype=torch.float32,  # float32 for stable CPU training
+            trust_remote_code=False
+        )
+        self.model.to(self.device)
+
+    # ------------------------------------------------------------------
+    # Public API (matches LLMTrainer)
+    # ------------------------------------------------------------------
+
+    def prepare_dataset(self, texts: List[str], max_length: int = 256) -> Dataset:
+        """
+        Tokenise a list of training texts into a Hugging Face Dataset.
+
+        Args:
+            texts: Formatted training strings
+            max_length: Token sequence length (256 recommended for CPU)
+
+        Returns:
+            Tokenised Dataset ready for the Trainer
+        """
+        def tokenize_function(examples):
+            return self.tokenizer(
+                examples['text'],
+                truncation=True,
+                max_length=max_length,
+                padding='max_length',
+                return_tensors=None
+            )
+
+        dataset = Dataset.from_dict({'text': texts})
+        tokenized_dataset = dataset.map(
+            tokenize_function,
+            batched=True,
+            remove_columns=dataset.column_names
+        )
+        return tokenized_dataset
+
+    def train(
+        self,
+        train_texts: List[str],
+        num_epochs: int = 3,
+        batch_size: int = 1,
+        learning_rate: float = 2e-5,
+        save_steps: int = 100,
+        max_length: int = 256,
+        max_steps: int = -1
+    ) -> None:
+        """
+        Fine-tune the model on conversation texts.
+
+        Args:
+            train_texts: List of formatted training strings
+            num_epochs: Training epochs (overridden if max_steps > 0)
+            batch_size: Per-device batch size (1 is safe on CPU for 1.5 B)
+            learning_rate: Peak learning rate (2e-5 suits instruction fine-tuning)
+            save_steps: Checkpoint frequency in gradient steps
+            max_length: Maximum sequence length in tokens
+            max_steps: Hard cap on gradient steps (-1 = epoch-based)
+        """
+        print(f"Preparing dataset with {len(train_texts)} samples...")
+        print("Note: Training Qwen2.5-1.5B on CPU is slow. Use a focused dataset.")
+
+        train_dataset = self.prepare_dataset(train_texts, max_length)
+
+        training_args = TrainingArguments(
+            output_dir=str(self.output_dir),
+            num_train_epochs=num_epochs,
+            max_steps=max_steps,
+            per_device_train_batch_size=batch_size,
+            gradient_accumulation_steps=4,   # effective batch = batch_size * 4
+            learning_rate=learning_rate,
+            save_steps=save_steps,
+            save_total_limit=2,
+            logging_steps=10,
+            logging_dir=str(self.output_dir / "logs"),
+            report_to="none",
+            use_cpu=(self.device == "cpu")
+        )
+
+        data_collator = DataCollatorForLanguageModeling(
+            tokenizer=self.tokenizer,
+            mlm=False  # causal LM
+        )
+
+        trainer = Trainer(
+            model=self.model,
+            args=training_args,
+            train_dataset=train_dataset,
+            data_collator=data_collator
+        )
+
+        print("Starting training...")
+        trainer.train()
+        print("Training completed!")
+
+    def save_model(self, save_path: Optional[str] = None) -> str:
+        """
+        Save the model and tokenizer as safetensors.
+
+        Uses a write-to-temp-then-move strategy to avoid memory-mapped file
+        conflicts on Windows (same approach as LLMTrainer).
+
+        Args:
+            save_path: Destination directory (defaults to output_dir)
+
+        Returns:
+            Absolute path where the model was saved
+        """
+        save_path = save_path or str(self.output_dir)
+        save_path = Path(save_path)
+
+        print(f"Saving model to {save_path}")
+
+        original_dtype = self.model.dtype if hasattr(self.model, 'dtype') else torch.float32
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_path = Path(temp_dir)
+
+                # Write safetensors to temp first
+                self.model.save_pretrained(temp_path, safe_serialization=True)
+                self.tokenizer.save_pretrained(temp_path)
+
+                # Release file handles before moving
+                del self.model
+                del self.tokenizer
+                gc.collect()
+
+                save_path.mkdir(parents=True, exist_ok=True)
+
+                for item in temp_path.iterdir():
+                    dest = save_path / item.name
+                    if item.is_file():
+                        if dest.exists():
+                            dest.unlink()
+                        shutil.copy2(item, dest)
+                    elif item.is_dir():
+                        if dest.exists():
+                            shutil.rmtree(dest)
+                        shutil.copytree(item, dest)
+
+            return str(save_path)
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to save model to {save_path}: {e}") from e
+
+        finally:
+            # Always restore the trainer to a usable state
+            try:
+                self.tokenizer = AutoTokenizer.from_pretrained(str(save_path))
+                self.model = AutoModelForCausalLM.from_pretrained(
+                    str(save_path),
+                    torch_dtype=original_dtype
+                )
+                self.model.to(self.device)
+            except Exception as reload_error:
+                print(f"Warning: Could not reload model after save: {reload_error}")
+                try:
+                    self._load_model()
+                except Exception as fallback_error:
+                    print(f"Critical: Could not restore model: {fallback_error}")
+
+    def load_trained_model(self, model_path: str) -> None:
+        """
+        Load a previously saved Qwen2.5 checkpoint for continued training.
+
+        Args:
+            model_path: Path to a directory containing config.json + safetensors
+        """
+        print(f"Loading trained model from {model_path}")
+        self.tokenizer = AutoTokenizer.from_pretrained(model_path)
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        if self.tokenizer.pad_token_id is None:
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            torch_dtype=torch.float32
+        )
+        self.model.to(self.device)


### PR DESCRIPTION
## Summary
This PR adds support for Qwen/Qwen2.5-1.5B model, including baseline ONNX export and fine-tuning capabilities. A new `QwenBuilder` class provides CPU-friendly training with sensible defaults, while two new CLI commands enable easy model export and training workflows.

## Key Changes

- **New `QwenBuilder` class** (`src/qwen_builder.py`):
  - Loads Qwen2.5-1.5B from Hugging Face and manages fine-tuning
  - CPU-optimized defaults: batch_size=1, gradient_accumulation=4, max_length=256, learning_rate=2e-5
  - Mirrors `LLMTrainer` API for drop-in compatibility
  - Implements safe model saving with temp-file strategy to avoid Windows file-locking issues
  - Supports checkpoint resumption with automatic learning rate reduction

- **New CLI commands** in `main.py`:
  - `qwen-baseline`: Export Qwen2.5-1.5B to ONNX directly from Hugging Face without training
    - Downloads safetensors weights (~3 GB) on first run
    - Includes optional test generation to verify export
  - `qwen-train`: Fine-tune Qwen2.5-1.5B on conversation data
    - Reuses existing `ConversationDataHandler` for data loading
    - Includes data quality analysis with warnings for low-quality datasets
    - Supports checkpoint resumption with automatic learning rate adjustment
    - Configurable epochs, batch size, learning rate, and sequence length

## Implementation Details

- Qwen2.5 tokenizer configuration: Sets pad_token to eos_token for proper attention mask generation
- Uses float32 for stable CPU training
- Gradient accumulation (steps=4) enables effective larger batch sizes on resource-constrained systems
- Model saving uses temporary directory + atomic move pattern to prevent corruption
- Checkpoint detection and resumption logic mirrors existing `train_model()` behavior
- Data quality warnings match existing training workflow

https://claude.ai/code/session_01PWEBKR4BeEJ6vttNB6DsaZ