### PR TITLE
Replace DistilGPT-2 with Qwen/Qwen2.5-0.5B as default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A CPU-friendly system for fine-tuning small language models on your own conversa
 
 ## Features
 
-- **Fine-tune DistilGPT-2** (or other GPT-2 variants) on your own conversation data
+- **Fine-tune Qwen** (or other causal LM variants) on your own conversation data
 - **Optimized for CPU** via ONNX export for 2–4× faster inference without requiring a GPU
 - **Continuous training** — automatically resumes from an existing checkpoint and uses a lower learning rate to prevent catastrophic forgetting
 - **Data quality validation** with automatic detection and filtering of low-quality conversations
@@ -55,7 +55,7 @@ mtnsails validate --data-file conversations.json --filter --output-file conversa
 
 ### 3. Train Your Model
 
-The `train` command fine-tunes a base language model on your conversation data. By default it uses DistilGPT-2, which runs comfortably on a CPU with minimal memory. You can configure how many training epochs to run, the batch size, and where to save the resulting model.
+The `train` command fine-tunes a base language model on your conversation data. By default it uses Qwen/Qwen2.5-0.5B, which runs comfortably on a CPU with minimal memory. You can configure how many training epochs to run, the batch size, and where to save the resulting model.
 
 If a previously trained model already exists in the output directory, MTN Sails automatically continues from that checkpoint at a lower learning rate to preserve existing knowledge — no manual steps required.
 
@@ -190,7 +190,7 @@ Bridges MTN Sails with the [taber_enviro](https://github.com/odds-get-evened/tab
 
 ### baseline
 
-Exports the base model (DistilGPT-2 by default) to ONNX format directly, without any fine-tuning. Useful for comparing base-model behavior against a fine-tuned version. An optional test flag runs a short generation after export to confirm the model is working.
+Exports the base model (Qwen/Qwen2.5-0.5B by default) to ONNX format directly, without any fine-tuning. Useful for comparing base-model behavior against a fine-tuned version. An optional test flag runs a short generation after export to confirm the model is working.
 
 ```bash
 mtnsails baseline --baseline-output ./onnx_baseline --test
@@ -262,7 +262,7 @@ mtnsails daemon --feedback-file ./live_pairs.jsonl --threshold 50 --max-steps 10
 The daemon polls the JSONL file every 30 seconds (configurable with `--poll-interval`).  Once at least `--threshold` new examples have arrived since the last retrain it:
 
 1. Loads the new pairs from the file.
-2. Fine-tunes the existing checkpoint in `./trained_model` (or trains from base `distilgpt2` if no checkpoint exists).  A low learning rate (1e-5) is used automatically when continuing from a checkpoint.
+2. Fine-tunes the existing checkpoint in `./trained_model` (or trains from base `Qwen/Qwen2.5-0.5B` if no checkpoint exists).  A low learning rate (1e-5) is used automatically when continuing from a checkpoint.
 3. Exports the updated model to ONNX and rotates directories atomically.
 
 ### Step 3 — Restart chat to use the new model

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -28,7 +28,7 @@ data_handler.add_conversation({
 })
 
 # 2. Train model
-trainer = LLMTrainer(model_name="distilgpt2", device="cpu")
+trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B", device="cpu")
 train_texts = data_handler.format_for_training()
 trainer.train(train_texts, num_epochs=3, batch_size=4)
 model_path = trainer.save_model()
@@ -83,7 +83,7 @@ Handles model fine-tuning on conversation data.
 ```python
 # Initialize with model
 trainer = LLMTrainer(
-    model_name="distilgpt2",  # or "gpt2", "microsoft/DialoGPT-small"
+    model_name="Qwen/Qwen2.5-0.5B",  # or "gpt2", "microsoft/DialoGPT-small"
     device="cpu"              # or "cuda"
 )
 
@@ -226,7 +226,7 @@ data = ConversationDataHandler()
 data.load_from_json("support_conversations.json")
 
 # Train on support data
-trainer = LLMTrainer(model_name="distilgpt2")
+trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B")
 trainer.train(data.format_for_training(), num_epochs=5)
 
 # Deploy as ONNX
@@ -246,7 +246,7 @@ print(response)
 data = ConversationDataHandler()
 data.load_from_json("domain_data.json")
 
-trainer = LLMTrainer(model_name="distilgpt2")
+trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B")
 trainer.train(
     data.format_for_training(),
     num_epochs=10,  # More epochs for domain expertise
@@ -293,7 +293,7 @@ response = chat.generate_response("Hello!")
 data = ConversationDataHandler()
 data.load_from_json("my_chats.json")
 
-trainer = LLMTrainer(model_name="distilgpt2")
+trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B")
 trainer.train(data.format_for_training(), num_epochs=3)
 ```
 
@@ -435,7 +435,7 @@ def continuous_learning_loop():
         data.load_from_json(chat.log_file)
         
         # Retrain model
-        trainer = LLMTrainer(model_name="distilgpt2")
+        trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B")
         trainer.train(data.format_for_training(), num_epochs=1)
         
         # Update model
@@ -491,11 +491,11 @@ except Exception as e:
 
 ```python
 # Use smaller batch sizes for limited RAM
-trainer = LLMTrainer(model_name="distilgpt2")
+trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B")
 trainer.train(train_texts, num_epochs=3, batch_size=2)
 
-# Use distilgpt2 instead of larger models for CPU
-trainer = LLMTrainer(model_name="distilgpt2", device="cpu")
+# Use Qwen/Qwen2.5-0.5B instead of larger models for CPU
+trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B", device="cpu")
 ```
 
 ### Inference Optimization

--- a/docs/CONTINUOUS_TRAINING.md
+++ b/docs/CONTINUOUS_TRAINING.md
@@ -44,7 +44,7 @@ python main.py pipeline --data-file programming_basics.json --epochs 3
 ```
 Output:
 ```
-🆕 No existing model found. Training from base model 'distilgpt2'
+🆕 No existing model found. Training from base model 'Qwen/Qwen2.5-0.5B'
 📚 Using standard learning rate (5e-05) for initial training
 ```
 
@@ -103,7 +103,7 @@ The system will check `./my_model` for existing trained models.
 ### Scenario 1: Fresh Start
 ```
 State: No models exist
-Behavior: Train from base model (distilgpt2)
+Behavior: Train from base model (Qwen/Qwen2.5-0.5B)
 Learning Rate: 5e-5 (standard)
 ```
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -58,7 +58,7 @@ The system follows OOP principles for modularity and reusability:
 ### LLMTrainer
 - **Purpose**: Fine-tune pre-trained language models
 - **Key Methods**:
-  - `__init__()`: Initialize with model name (default: distilgpt2)
+  - `__init__()`: Initialize with model name (default: Qwen/Qwen2.5-0.5B)
   - `prepare_dataset()`: Tokenize and prepare training data
   - `train()`: Execute training loop with specified epochs
   - `save_model()`: Save model with safetensors format
@@ -164,7 +164,7 @@ class TensorRTConverter(ONNXConverter):
 ## Performance Considerations
 
 ### CPU Optimization
-- Uses `distilgpt2` (82M params) by default
+- Uses `Qwen/Qwen2.5-0.5B` (494M params) by default
 - ONNX format for faster inference
 - `torch.float32` for CPU compatibility
 
@@ -182,7 +182,7 @@ class TensorRTConverter(ONNXConverter):
 
 ### 1. Model Selection
 Choose models based on your hardware:
-- CPU: distilgpt2, gpt2-small
+- CPU: Qwen/Qwen2.5-0.5B, gpt2-small
 - GPU: gpt2-medium, larger models
 
 ### 2. Training

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -2,7 +2,7 @@
 
 ## Overview
 This repository implements a complete LLM training and ONNX conversion system with a focus on:
-- **CPU-friendly operation** using small models like DistilGPT-2
+- **CPU-friendly operation** using small models like Qwen/Qwen2.5-0.5B
 - **Object-oriented design** for modularity and reusability
 - **Streamlined code** with minimal dependencies
 - **Production-ready** ONNX export for efficient inference
@@ -18,7 +18,7 @@ This repository implements a complete LLM training and ONNX conversion system wi
    - ~140 lines of clean, reusable code
 
 2. **trainer.py** (LLMTrainer)
-   - Load pre-trained models (default: distilgpt2)
+   - Load pre-trained models (default: Qwen/Qwen2.5-0.5B)
    - Fine-tune on conversation data
    - Save models with safetensors
    - ~200 lines with comprehensive training logic
@@ -121,7 +121,7 @@ This repository implements a complete LLM training and ONNX conversion system wi
 - Composition for complex workflows
 
 ### ✅ CPU-Friendly
-- Uses DistilGPT-2 (82M parameters)
+- Uses Qwen/Qwen2.5-0.5B (494M parameters)
 - torch.float32 for CPU compatibility
 - ONNX Runtime optimizations
 - Small batch sizes and efficient memory usage
@@ -270,7 +270,7 @@ Results:
 ## Technical Highlights
 
 ### Design Decisions
-- **DistilGPT-2**: Best balance of size and quality for CPU
+- **Qwen/Qwen2.5-0.5B**: Best balance of size and quality for CPU
 - **Lazy Imports**: Avoid loading ML libs unnecessarily
 - **Safetensors**: Secure model serialization
 - **ONNX Runtime**: 2-4x faster than PyTorch inference

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -218,7 +218,7 @@ The implementation provides clear, emoji-enhanced messages:
 ```bash
 # Session 1: Initial training
 python main.py pipeline --data-file programming_basics.json --epochs 3
-# Output: 🆕 Training new model from base 'distilgpt2'
+# Output: 🆕 Training new model from base 'Qwen/Qwen2.5-0.5B'
 # Model learns: Python, variables, functions
 
 # Session 2: Add more knowledge

--- a/docs/LOSS_CONFIGURATION.md
+++ b/docs/LOSS_CONFIGURATION.md
@@ -21,7 +21,7 @@ Cross-entropy loss is the optimal choice for causal language modeling because:
 
 - Setting `loss_type=None` triggers a deprecation warning (which MTN Sails suppresses)
 - The model automatically uses the correct loss function based on its architecture
-- For causal LMs (GPT-2, DistilGPT-2), this is always cross-entropy loss
+- For causal LMs (GPT-2, Qwen), this is always cross-entropy loss
 
 ## Alternative Approaches to Improve Model Performance
 
@@ -99,7 +99,7 @@ python main.py train --batch-size 8
 
 ```bash
 # Smallest (fastest, less capable)
-python main.py train --model-name distilgpt2
+python main.py train --model-name Qwen/Qwen2.5-0.5B
 
 # Medium (good balance)
 python main.py train --model-name gpt2

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -142,7 +142,7 @@ data = ConversationDataHandler()
 data.load_from_json("conversations.json")
 
 # 2. Train
-trainer = LLMTrainer(model_name="distilgpt2", device="cpu")
+trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B", device="cpu")
 trainer.train(data.format_for_training(), num_epochs=3)
 model_path = trainer.save_model("./trained")
 
@@ -193,7 +193,7 @@ data = ConversationDataHandler()
 data.load_from_json("support_conversations.json")
 
 # Train on support data
-trainer = LLMTrainer(model_name="distilgpt2")
+trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B")
 trainer.train(data.format_for_training(), num_epochs=5)
 
 # Deploy as ONNX
@@ -211,7 +211,7 @@ response = chat.generate_response("How do I reset my password?")
 data = ConversationDataHandler()
 data.load_from_json("domain_data.json")
 
-trainer = LLMTrainer(model_name="distilgpt2")
+trainer = LLMTrainer(model_name="Qwen/Qwen2.5-0.5B")
 trainer.train(
     data.format_for_training(),
     num_epochs=10,  # More epochs for domain expertise
@@ -259,7 +259,7 @@ for q, a in zip(questions, responses):
 python main.py train --batch-size 2
 
 # Use smaller model
-python main.py train --model-name distilgpt2
+python main.py train --model-name Qwen/Qwen2.5-0.5B
 ```
 
 ### Slow Training

--- a/examples/demo_continuous_training.py
+++ b/examples/demo_continuous_training.py
@@ -54,12 +54,12 @@ def simulate_training_scenario(scenario_name, setup_func, expected_behavior):
         elif onnx_exists:
             print(f"  🔄 Found existing ONNX model at {onnx_dir}")
             print(f"  ⚠️  Source trained model not found at {output_dir}")
-            print("  🆕 Training from base model 'distilgpt2'")
+            print("  🆕 Training from base model 'Qwen/Qwen2.5-0.5B'")
         elif model_exists:
             print(f"  🔄 Found existing trained model at {output_dir}")
             print("  🔄 Continuing training from this checkpoint...")
         else:
-            print("  🆕 No existing model found. Training from base model 'distilgpt2'")
+            print("  🆕 No existing model found. Training from base model 'Qwen/Qwen2.5-0.5B'")
         
         # Simulate train_model messages
         print("\n  === Training Model ===")
@@ -68,7 +68,7 @@ def simulate_training_scenario(scenario_name, setup_func, expected_behavior):
             print("  🔄 Continuing training from this checkpoint...")
             print("  📚 Using lower learning rate (1e-05) for fine-tuning to preserve existing knowledge")
         else:
-            print("  🆕 Training new model from base 'distilgpt2'")
+            print("  🆕 Training new model from base 'Qwen/Qwen2.5-0.5B'")
             print("  📚 Using standard learning rate (5e-05) for initial training")
         
     finally:
@@ -114,7 +114,7 @@ def main():
         setup_fresh_start,
         [
             "No existing models found",
-            "Train from base model (distilgpt2)",
+            "Train from base model (Qwen/Qwen2.5-0.5B)",
             "Use standard learning rate (5e-05)",
             "Model will be saved to ./trained_model",
             "ONNX will be created at ./onnx_model"
@@ -191,7 +191,7 @@ def main():
     print("""
 # First training session
 python main.py pipeline --data-file data1.json --epochs 3
-# Output: Training from base model distilgpt2
+# Output: Training from base model Qwen/Qwen2.5-0.5B
 
 # Second training session (add more knowledge)
 python main.py pipeline --data-file data2.json --epochs 2

--- a/examples/example.py
+++ b/examples/example.py
@@ -35,10 +35,10 @@ def main():
     
     # Step 2: Train Model
     print("Step 2: Training the model...")
-    print("Note: This uses a small model (distilgpt2) suitable for CPU training\n")
-    
+    print("Note: This uses Qwen/Qwen2.5-0.5B suitable for CPU training\n")
+
     trainer = LLMTrainer(
-        model_name="distilgpt2",
+        model_name="Qwen/Qwen2.5-0.5B",
         output_dir="./example_trained_model",
         device="cpu"
     )

--- a/main.py
+++ b/main.py
@@ -463,7 +463,7 @@ def taber_bridge(args):
 
 def baseline_model(args):
     """
-    Create baseline ONNX model from base DistilGPT-2 without training.
+    Create baseline ONNX model from base Qwen model without training.
     This gives you a fresh, untouched model to test against.
     
     Args:
@@ -618,7 +618,7 @@ def main():
     # Train command
     train_parser = subparsers.add_parser('train', help='Train a model')
     train_parser.add_argument('--data-file', type=str, help='Path to conversation data JSON')
-    train_parser.add_argument('--model-name', type=str, default='distilgpt2', help='Base model name')
+    train_parser.add_argument('--model-name', type=str, default='Qwen/Qwen2.5-0.5B', help='Base model name')
     train_parser.add_argument('--output-dir', type=str, default='./trained_model', help='Output directory')
     train_parser.add_argument('--device', type=str, default='cpu', help='Device (cpu/cuda)')
     train_parser.add_argument('--epochs', type=int, default=3, help='Number of epochs')
@@ -660,7 +660,7 @@ def main():
     # Pipeline command
     pipeline_parser = subparsers.add_parser('pipeline', help='Run full pipeline')
     pipeline_parser.add_argument('--data-file', type=str, help='Path to conversation data JSON')
-    pipeline_parser.add_argument('--model-name', type=str, default='distilgpt2', help='Base model name')
+    pipeline_parser.add_argument('--model-name', type=str, default='Qwen/Qwen2.5-0.5B', help='Base model name')
     pipeline_parser.add_argument('--output-dir', type=str, default='./trained_model', help='Output directory')
     pipeline_parser.add_argument('--onnx-output', type=str, default='./onnx_model', help='ONNX output path')
     pipeline_parser.add_argument('--device', type=str, default='cpu', help='Device (cpu/cuda)')
@@ -721,8 +721,8 @@ def main():
                                help='Daemon state file (default: ./daemon_state.json)')
     daemon_parser.add_argument('--threshold', type=int, default=50,
                                help='New examples needed before retraining (default: 50)')
-    daemon_parser.add_argument('--model-name', type=str, default='distilgpt2',
-                               help='Base model when no checkpoint exists (default: distilgpt2)')
+    daemon_parser.add_argument('--model-name', type=str, default='Qwen/Qwen2.5-0.5B',
+                               help='Base model when no checkpoint exists (default: Qwen/Qwen2.5-0.5B)')
     daemon_parser.add_argument('--output-dir', type=str, default='./trained_model',
                                help='PyTorch checkpoint directory (default: ./trained_model)')
     daemon_parser.add_argument('--onnx-output', type=str, default='./onnx_model',
@@ -739,8 +739,8 @@ def main():
 
     # Baseline command
     baseline_parser = subparsers.add_parser('baseline', help='Export base model to ONNX without training')
-    baseline_parser.add_argument('--model-name', type=str, default='distilgpt2',
-                                help='Base model to export (default: distilgpt2)')
+    baseline_parser.add_argument('--model-name', type=str, default='Qwen/Qwen2.5-0.5B',
+                                help='Base model to export (default: Qwen/Qwen2.5-0.5B)')
     baseline_parser.add_argument('--baseline-output', type=str, default='./baseline_onnx',
                                 help='Output directory for baseline ONNX model (default: ./baseline_onnx)')
     baseline_parser.add_argument('--test', action='store_true',

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -97,7 +97,7 @@ def run_daemon(
     feedback_file: str = "./live_pairs.jsonl",
     state_file: str = "./daemon_state.json",
     retrain_threshold: int = 50,
-    model_name: str = "distilgpt2",
+    model_name: str = "Qwen/Qwen2.5-0.5B",
     trained_model_dir: str = "./trained_model",
     onnx_output_dir: str = "./onnx_model",
     poll_interval: int = 30,

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -31,7 +31,7 @@ class LLMTrainer:
     
     def __init__(
         self,
-        model_name: str = "distilgpt2",
+        model_name: str = "Qwen/Qwen2.5-0.5B",
         output_dir: str = "./trained_model",
         device: str = "cpu"
     ):

--- a/tests/integration_test_continuous_training.py
+++ b/tests/integration_test_continuous_training.py
@@ -37,8 +37,8 @@ def test_scenario_1_fresh_start():
         print(f"ONNX exists: {onnx_exists}")
         
         if not model_exists and not onnx_exists:
-            print("✅ PASS: Should train from base model (distilgpt2)")
-            print("Expected message: '🆕 Training new model from base 'distilgpt2''")
+            print("✅ PASS: Should train from base model (Qwen/Qwen2.5-0.5B)")
+            print("Expected message: '🆕 Training new model from base 'Qwen/Qwen2.5-0.5B''")
             return True
         else:
             print("❌ FAIL: Unexpected state")
@@ -109,7 +109,7 @@ def test_scenario_3_onnx_exists_but_no_trained():
             print("Expected messages:")
             print("  '🔄 Found existing ONNX model at ./onnx_model'")
             print("  '⚠️  Source trained model not found at ./trained_model'")
-            print("  '🆕 Training from base model 'distilgpt2''")
+            print("  '🆕 Training from base model 'Qwen/Qwen2.5-0.5B''")
             return True
         else:
             print("❌ FAIL: Unexpected state")
@@ -180,7 +180,7 @@ def test_scenario_5_incomplete_model():
         
         if not model_exists:
             print("✅ PASS: Incomplete model should be treated as new training")
-            print("Expected message: '🆕 Training new model from base 'distilgpt2''")
+            print("Expected message: '🆕 Training new model from base 'Qwen/Qwen2.5-0.5B''")
             return True
         else:
             print("❌ FAIL: Incomplete model should not be considered valid")

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -23,7 +23,7 @@ class TestBaselineCommand(unittest.TestCase):
         
         # Add baseline parser similar to main.py
         baseline_parser = subparsers.add_parser('baseline')
-        baseline_parser.add_argument('--model-name', type=str, default='distilgpt2')
+        baseline_parser.add_argument('--model-name', type=str, default='Qwen/Qwen2.5-0.5B')
         baseline_parser.add_argument('--baseline-output', type=str, default='./baseline_onnx')
         baseline_parser.add_argument('--test', action='store_true')
     
@@ -34,7 +34,7 @@ class TestBaselineCommand(unittest.TestCase):
         
         # Verify command was parsed correctly
         self.assertEqual(args.command, 'baseline')
-        self.assertEqual(args.model_name, 'distilgpt2')
+        self.assertEqual(args.model_name, 'Qwen/Qwen2.5-0.5B')
         self.assertEqual(args.baseline_output, './baseline_onnx')
         self.assertFalse(args.test)
     


### PR DESCRIPTION
## Summary
This PR updates the default language model across the entire codebase from DistilGPT-2 to Qwen/Qwen2.5-0.5B. This change improves model quality while maintaining CPU-friendly operation, as Qwen2.5-0.5B offers better performance characteristics for conversation fine-tuning.

## Key Changes
- **Default model parameter**: Updated all instances of `model_name="distilgpt2"` to `model_name="Qwen/Qwen2.5-0.5B"` in:
  - `src/trainer.py` (LLMTrainer class initialization)
  - `src/daemon.py` (daemon training function)
  - `main.py` (all CLI subcommands: train, pipeline, daemon, baseline)
  - `examples/example.py` and `examples/demo_continuous_training.py`

- **Documentation updates**: Updated all references in:
  - API_REFERENCE.md
  - README.md
  - QUICKSTART.md
  - IMPLEMENTATION.md
  - DEVELOPMENT.md
  - CONTINUOUS_TRAINING.md
  - LOSS_CONFIGURATION.md
  - IMPLEMENTATION_SUMMARY.md

- **Test updates**: Updated test expectations in:
  - `tests/test_baseline.py`
  - `tests/integration_test_continuous_training.py`

## Implementation Details
- The model change is backward compatible—users can still specify alternative models via the `--model-name` CLI argument or constructor parameter
- All documentation examples now reflect the new default while maintaining references to alternative models (gpt2, DialoGPT-small) where appropriate
- The change maintains the CPU-friendly focus of the project while providing improved model quality for conversation fine-tuning tasks

https://claude.ai/code/session_01S9qJq88pD41Nt6TSCs6TSE